### PR TITLE
plainErrors calculation in DARP python project different than in java project

### DIFF
--- a/darp.py
+++ b/darp.py
@@ -122,7 +122,7 @@ class DARP():
         self.connectivity = np.zeros((self.droneNo, self.rows, self.cols))
         self.BinaryRobotRegions = np.zeros((self.droneNo, self.rows, self.cols), dtype=bool)
 
-        self.AllDistances, self.termThr, self.Notiles, self.DesireableAssign, self.TilesImportance, self.MinimumImportance, self.MaximumImportance= self.construct_Assignment_Matrix()
+        self.AllDistances, self.termThr, self.Notiles, self.DesireableAssign, self.TilesImportance, self.MinimumImportance, self.MaximumImportance, self.effectiveSize = self.construct_Assignment_Matrix()
         self.MetricMatrix = copy.deepcopy(self.AllDistances)
         self.BWlist = np.zeros((self.droneNo, self.rows, self.cols))
         self.ArrayOfElements = np.zeros(self.droneNo)
@@ -241,7 +241,7 @@ class DARP():
                                                                       self.NormalizedEuclideanDistanceBinary(True, BinaryRobot, BinaryNonRobot),
                                                                       self.NormalizedEuclideanDistanceBinary(False, BinaryRobot, BinaryNonRobot),self.CCvariation)
                     ConnectedMultiplierList[r, :, :] = ConnectedMultiplier
-                    plainErrors[r] = self.ArrayOfElements[r]/(self.DesireableAssign[r]*self.droneNo)
+                    plainErrors[r] = self.ArrayOfElements[r] / self.effectiveSize
                     if plainErrors[r] < downThres:
                         divFairError[r] = downThres - plainErrors[r]
                     elif plainErrors[r] > upperThres:
@@ -367,7 +367,7 @@ class DARP():
                     if TilesImportance[r, x, y] < MinimumImportance[r]:
                         MinimumImportance[r] = TilesImportance[r, x, y]
 
-        return AllDistances, termThr, Notiles, DesireableAssign, TilesImportance, MinimumImportance, MaximumImportance
+        return AllDistances, termThr, Notiles, DesireableAssign, TilesImportance, MinimumImportance, MaximumImportance, effectiveSize
 
     def calculateCriterionMatrix(self, TilesImportance, MinimumImportance, MaximumImportance, correctionMult, smallerthan_zero,):
         returnCrit = np.zeros((self.rows, self.cols))


### PR DESCRIPTION
I don't know why you changed the `plainErrors `calculation inside your `divideRegions` (earlier `update`) methode, but the calc is different in the DARP Java Project.
If you calc 
`plainErrors[r] = self.ArrayOfElements[r]/(self.DesireableAssign[r]*self.droneNo)`
 with `self.DesireableAssign` being calced by non-fair portions like [0.3, 0.5, 0.20], the result `plainErrors[r]` is different to the java approach:
 `plainErrors[r] = ArrayOfElements[r] / (double) effectiveSize;`
 where `effectiveSize` is `int effectiveSize = NoTiles - nr - ob;` (in the java project they dont have and `empty_space` attribute.
Can you tell me why you changed it that way in the python project?
Thanks in advance :)