### PR TITLE
Small logic changes and clearing code

### DIFF
--- a/darp.py
+++ b/darp.py
@@ -236,6 +236,7 @@ class DARP:
                 plainErrors = np.zeros((self.droneNo))
                 divFairError = np.zeros((self.droneNo))
 
+                self.update_connectivity()
                 for r in range(self.droneNo):
                     ConnectedMultiplier = np.ones((self.rows, self.cols))
                     ConnectedRobotRegions[r] = True

--- a/darp.py
+++ b/darp.py
@@ -1,5 +1,4 @@
 import numpy as np
-import copy
 import sys
 import cv2
 from Visualization import darp_area_visualization
@@ -125,7 +124,7 @@ class DARP:
 
         self.droneNo = len(self.initial_positions)
         self.A = np.zeros((self.rows, self.cols))
-        self.defineGridEnv()
+        self.GridEnv = self.defineGridEnv()
    
         self.connectivity = np.zeros((self.droneNo, self.rows, self.cols))
         self.BinaryRobotRegions = np.zeros((self.droneNo, self.rows, self.cols), dtype=bool)
@@ -183,17 +182,17 @@ class DARP:
         return initial_positions, obstacles_positions, portions
           
     def defineGridEnv(self):
-        self.GridEnv = np.full(shape=(self.rows, self.cols), fill_value=-1)  # create non obstacle map with value -1
+        GridEnv = np.full(shape=(self.rows, self.cols), fill_value=-1)  # create non obstacle map with value -1
         
         # obstacle tiles value is -2
         for idx, obstacle_pos in enumerate(self.obstacles_positions):
-            self.GridEnv[obstacle_pos[0], obstacle_pos[1]] = -2
+            GridEnv[obstacle_pos[0], obstacle_pos[1]] = -2
         for idx, es_pos in enumerate(self.empty_space):
-            self.GridEnv[es_pos] = -2
+            GridEnv[es_pos] = -2
 
         connectivity = np.zeros((self.rows, self.cols))
         
-        mask = np.where(self.GridEnv == -1)
+        mask = np.where(GridEnv == -1)
         connectivity[mask[0], mask[1]] = 255
         image = np.uint8(connectivity)
         num_labels, labels_im = cv2.connectedComponents(image, connectivity=4)
@@ -204,10 +203,10 @@ class DARP:
         
         # initial robot tiles will have their array.index as value
         for idx, robot in enumerate(self.initial_positions):
-            self.GridEnv[robot] = idx
+            GridEnv[robot] = idx
             self.A[robot] = idx
 
-        return
+        return GridEnv
 
     def divideRegions(self):
         success = False

--- a/darp.py
+++ b/darp.py
@@ -130,8 +130,7 @@ class DARP:
         self.connectivity = np.zeros((self.droneNo, self.rows, self.cols))
         self.BinaryRobotRegions = np.zeros((self.droneNo, self.rows, self.cols), dtype=bool)
 
-        self.AllDistances, self.termThr, self.Notiles, self.DesireableAssign, self.TilesImportance, self.MinimumImportance, self.MaximumImportance= self.construct_Assignment_Matrix()
-        self.MetricMatrix = copy.deepcopy(self.AllDistances)
+        self.MetricMatrix, self.termThr, self.Notiles, self.DesireableAssign, self.TilesImportance, self.MinimumImportance, self.MaximumImportance= self.construct_Assignment_Matrix()
         self.ArrayOfElements = np.zeros(self.droneNo)
         self.color = []
 

--- a/darp.py
+++ b/darp.py
@@ -126,7 +126,7 @@ class DARP:
         self.A = np.zeros((self.rows, self.cols))
         self.GridEnv = self.defineGridEnv()
    
-        self.connectivity = np.zeros((self.droneNo, self.rows, self.cols))
+        self.connectivity = np.zeros((self.droneNo, self.rows, self.cols), dtype=np.uint8)
         self.BinaryRobotRegions = np.zeros((self.droneNo, self.rows, self.cols), dtype=bool)
 
         self.MetricMatrix, self.termThr, self.Notiles, self.DesireableAssign, self.TilesImportance, self.MinimumImportance, self.MaximumImportance= self.construct_Assignment_Matrix()
@@ -239,9 +239,7 @@ class DARP:
                 for r in range(self.droneNo):
                     ConnectedMultiplier = np.ones((self.rows, self.cols))
                     ConnectedRobotRegions[r] = True
-                    self.update_connectivity()
-                    image = np.uint8(self.connectivity[r, :, :])
-                    num_labels, labels_im = cv2.connectedComponents(image, connectivity=4)
+                    num_labels, labels_im = cv2.connectedComponents(self.connectivity[r, :, :], connectivity=4)
                     if num_labels > 2:
                         ConnectedRobotRegions[r] = False
                         BinaryRobot, BinaryNonRobot = constructBinaryImages(labels_im, self.initial_positions[r], self.rows, self.cols)
@@ -325,7 +323,7 @@ class DARP:
         return True
 
     def update_connectivity(self):
-        self.connectivity = np.zeros((self.droneNo, self.rows, self.cols))
+        self.connectivity = np.zeros((self.droneNo, self.rows, self.cols), dtype=np.uint8)
         for i in range(self.droneNo):
             mask = np.where(self.A == i)
             self.connectivity[i, mask[0], mask[1]] = 255


### PR DESCRIPTION
Hey,
I realised several things over the last days:

1. the `self.update_connectivity` methode is getting called <number_of_robots> times, but nothing changes for the `self.A` array and therefore `self.connectivity` in between the calls. Thats why I would shift it outside the loop through the robots. Gives a small acceleration.
2. if you define the `self.connectivity` array with the right `dtype=np.uint8` you can avoid another casting for it later.
3. the `self.AllDistances` attribute is never used, but you are creating a deepcopy from it to use it as `self.MetricMatrix` attribute. I suggest you declare `self.MetricMatrix` right away.
4. the declaration of `self.GridEnv` inside the declare methode issues a warning inside some IDEs. I suggest declare it inside the `DARP.__init__` like a lot of other attributes